### PR TITLE
update nuget packages & target versions to net 8.0

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -4,14 +4,12 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
-      - '.github/**'
       - 'Examples/**'
       - 'README**'
   pull_request:
     branches: [ master ]
     types: [ opened, synchronize ]
     paths-ignore:
-      - '.github/**'
       - 'Examples/**'
       - 'README**'
 
@@ -64,36 +62,26 @@ jobs:
           ${{ runner.os }}-nuget-
           
     # Setup .NET frameworks
-    - name: Setup .NET Core 2.1
+    - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-       dotnet-version: '2.1'
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v1
-      with:
-       dotnet-version: '3.1'
-    - name: Setup .NET Core 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-       dotnet-version: '5.0'
+        dotnet-version: '8.0'
 
     - name: Setup NuGet
       uses: nuget/setup-nuget@v1
 
-    # install dependencies 
+    # Install dependencies 
     - name: NuGet Restore
       run: nuget restore ZotapaySDK.sln
       
-    # build project
+    # Build project
     - name: Build
       run: dotnet build --configuration ${{env.config}} --no-restore
       
     # run tests with built project
     - name: Test
       run: |
-        dotnet test --framework netcoreapp2.1 --no-restore --no-build --configuration ${{env.config}} --logger GitHubActions
-        dotnet test --framework netcoreapp3.1 --no-restore --no-build --configuration ${{env.config}}
-        dotnet test --framework net5.0 --no-restore --no-build --configuration ${{env.config}} --settings coverlet.runsettings
+        dotnet test --framework net8.0 --no-restore --no-build --configuration ${{env.config}} --settings coverlet.runsettings
 
     - name: Upload coverage
       uses: codecov/codecov-action@v1

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/Tests/CallbackTests.cs
+++ b/Tests/CallbackTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Tests
 {
     using NUnit.Framework;
+    using NUnit.Framework.Legacy;
 
     public class CallbackTests
     {
@@ -14,10 +15,10 @@
             // Act
             var actual = client.Parse(callback);
 
-            // Assert
-            Assert.IsTrue(actual.IsVerified);
-            Assert.IsEmpty(actual.ErrorMessage);
-            Assert.AreEqual("APPROVED", actual.Status);
+            // ClassicAssert
+            ClassicAssert.IsTrue(actual.IsVerified);
+            ClassicAssert.IsEmpty(actual.ErrorMessage);
+            ClassicAssert.AreEqual("APPROVED", actual.Status);
         }
 
         [Test]
@@ -31,9 +32,9 @@
             // Act
             var actual = client.Parse(callback);
 
-            // Assert
-            Assert.IsFalse(actual.IsVerified);
-            Assert.AreEqual(expectedErrorMessage, actual.ErrorMessage);
+            // ClassicAssert
+            ClassicAssert.IsFalse(actual.IsVerified);
+            ClassicAssert.AreEqual(expectedErrorMessage, actual.ErrorMessage);
         }
 
         [Test]
@@ -47,9 +48,9 @@
             // Act
             var actual = client.Parse(callback);
 
-            // Assert
-            Assert.IsFalse(actual.IsVerified);
-            Assert.AreEqual(expectedErrorMessage, actual.ErrorMessage);
+            // ClassicAssert
+            ClassicAssert.IsFalse(actual.IsVerified);
+            ClassicAssert.AreEqual(expectedErrorMessage, actual.ErrorMessage);
         }
     }
 }

--- a/Tests/DepositTests.cs
+++ b/Tests/DepositTests.cs
@@ -6,6 +6,7 @@ namespace Tests
     using Zotapay.Models;
     using Zotapay.Models.Deposit;
     using Zotapay;
+    using NUnit.Framework.Legacy;
 
     public class Tests
     {
@@ -50,13 +51,13 @@ namespace Tests
             // Act
             MGDepositResult actual = client.InitDeposit(DepositRequest).Result;
 
-            // Assert
-            Assert.IsTrue(actual.IsSuccess);
-            Assert.AreEqual(expectedResult.Data.DepositUrl, actual.Data.DepositUrl);
-            Assert.AreEqual(expectedResult.Data.MerchantOrderID, actual.Data.MerchantOrderID);
-            Assert.AreEqual(expectedResult.Data.OrderID, actual.Data.OrderID);
-            Assert.AreEqual(expectedResult.Code, actual.Code);
-            Assert.AreEqual(expectedResult.Message, actual.Message);
+            // ClassicAssert
+            ClassicAssert.IsTrue(actual.IsSuccess);
+            ClassicAssert.AreEqual(expectedResult.Data.DepositUrl, actual.Data.DepositUrl);
+            ClassicAssert.AreEqual(expectedResult.Data.MerchantOrderID, actual.Data.MerchantOrderID);
+            ClassicAssert.AreEqual(expectedResult.Data.OrderID, actual.Data.OrderID);
+            ClassicAssert.AreEqual(expectedResult.Code, actual.Code);
+            ClassicAssert.AreEqual(expectedResult.Message, actual.Message);
         }
 
         [Test]
@@ -78,11 +79,11 @@ namespace Tests
             // Act
             MGDepositResult actual = client.InitDeposit(DepositRequest).Result;
 
-            // Assert
-            Assert.IsFalse(actual.IsSuccess);
-            Assert.AreEqual(expectedResult.Data, actual.Data);
-            Assert.AreEqual(expectedResult.Code, actual.Code);
-            Assert.AreEqual(expectedResult.Message, actual.Message);
+            // ClassicAssert
+            ClassicAssert.IsFalse(actual.IsSuccess);
+            ClassicAssert.AreEqual(expectedResult.Data, actual.Data);
+            ClassicAssert.AreEqual(expectedResult.Code, actual.Code);
+            ClassicAssert.AreEqual(expectedResult.Message, actual.Message);
         }
 
         [Test]
@@ -99,9 +100,9 @@ namespace Tests
             // Act
             MGDepositResult actual = client.InitDeposit(DepositRequest).Result;
 
-            // Assert
-            Assert.IsFalse(actual.IsSuccess);
-            Assert.AreEqual(expectedErrorMessage, actual.Message);
+            // ClassicAssert
+            ClassicAssert.IsFalse(actual.IsSuccess);
+            ClassicAssert.AreEqual(expectedErrorMessage, actual.Message);
         }
 
         [Test]
@@ -119,9 +120,9 @@ namespace Tests
             // Act
             MGDepositResult actualDepositResult = clientMock.InitDeposit(depositRequest).Result;
 
-            // Assert
-            Assert.IsFalse(actualDepositResult.IsSuccess);
-            Assert.AreEqual(expectedErrorMessage, actualDepositResult.Message);
+            // ClassicAssert
+            ClassicAssert.IsFalse(actualDepositResult.IsSuccess);
+            ClassicAssert.AreEqual(expectedErrorMessage, actualDepositResult.Message);
         }
 
         [Test]
@@ -141,8 +142,8 @@ namespace Tests
             // Act
             request.GenerateSignature(endpointId, secret);
 
-            // Assert
-            Assert.AreEqual(expectedSignature, request.Signature);
+            // ClassicAssert
+            ClassicAssert.AreEqual(expectedSignature, request.Signature);
         }
 
         [Test]
@@ -157,8 +158,8 @@ namespace Tests
             // Act
             MGClient client = new MGClient(merchantSecret, endpointId, requestUrl, merchantId);
 
-            // Assert
-            Assert.IsNotNull(client);
+            // ClassicAssert
+            ClassicAssert.IsNotNull(client);
         }
 
         [Test]
@@ -172,9 +173,9 @@ namespace Tests
             // Act
             MGDepositResult actual = client.InitDeposit(request).Result;
 
-            // Assert
-            Assert.IsFalse(actual.IsSuccess);
-            Assert.AreEqual(expectedErrorMessage, actual.Message);
+            // ClassicAssert
+            ClassicAssert.IsFalse(actual.IsSuccess);
+            ClassicAssert.AreEqual(expectedErrorMessage, actual.Message);
         }
 
         [Test]
@@ -188,9 +189,9 @@ namespace Tests
             // Act
             var actualResult = await clientWithConfig.InitCardDeposit(DepositOrderRequest);
 
-            // Assert
-            Assert.IsFalse(actualResult.IsSuccess);
-            Assert.AreEqual(expectedErrorMessage, actualResult.Message);
+            // ClassicAssert
+            ClassicAssert.IsFalse(actualResult.IsSuccess);
+            ClassicAssert.AreEqual(expectedErrorMessage, actualResult.Message);
         }
     }
 }

--- a/Tests/PayoutTests.cs
+++ b/Tests/PayoutTests.cs
@@ -4,6 +4,7 @@
     using System.Net;
     using Zotapay;
     using Zotapay.Models.Payout;
+    using NUnit.Framework.Legacy;
 
     public class PayoutTests
     {
@@ -49,12 +50,12 @@
             // Act
             MGPayoutResult actual = client.InitPayout(payoutRequest).Result;
 
-            // Assert
-            Assert.IsTrue(actual.IsSuccess);
-            Assert.AreEqual(expectedResult.Code, actual.Code);
-            Assert.AreEqual(expectedResult.Message, actual.Message);
-            Assert.AreEqual(expectedResult.Data.orderID, actual.Data.orderID);
-            Assert.AreEqual(expectedResult.Data.merchantOrderID, actual.Data.merchantOrderID);
+            // ClassicAssert
+            ClassicAssert.IsTrue(actual.IsSuccess);
+            ClassicAssert.AreEqual(expectedResult.Code, actual.Code);
+            ClassicAssert.AreEqual(expectedResult.Message, actual.Message);
+            ClassicAssert.AreEqual(expectedResult.Data.orderID, actual.Data.orderID);
+            ClassicAssert.AreEqual(expectedResult.Data.merchantOrderID, actual.Data.merchantOrderID);
         }
 
         [Test]
@@ -99,11 +100,11 @@
             // Act
             MGPayoutResult actual = client.InitPayout(payoutRequest).Result;
 
-            // Assert
-            Assert.IsFalse(actual.IsSuccess);
-            Assert.AreEqual(expectedResult.Code, actual.Code);
-            Assert.AreEqual(expectedResult.Message, actual.Message);
-            Assert.AreEqual(expectedResult.Data, actual.Data);
+            // ClassicAssert
+            ClassicAssert.IsFalse(actual.IsSuccess);
+            ClassicAssert.AreEqual(expectedResult.Code, actual.Code);
+            ClassicAssert.AreEqual(expectedResult.Message, actual.Message);
+            ClassicAssert.AreEqual(expectedResult.Data, actual.Data);
         }
     }
 }

--- a/Tests/StatusCheckTests.cs
+++ b/Tests/StatusCheckTests.cs
@@ -3,6 +3,7 @@
     using NUnit.Framework;
     using System.Net;
     using Zotapay.Models.OrderStatusCheck;
+    using NUnit.Framework.Legacy;
 
     class StatusCheckTests
     {
@@ -17,9 +18,9 @@
             // Act 
             MGQueryTxnResult actual = client.CheckOrderStatus(queryRequest).Result;
 
-            // Assert
-            Assert.IsFalse(actual.IsSuccess);
-            Assert.AreEqual(expectedMessage, actual.Message);
+            // ClassicAssert
+            ClassicAssert.IsFalse(actual.IsSuccess);
+            ClassicAssert.AreEqual(expectedMessage, actual.Message);
         }
 
         [Test]
@@ -38,9 +39,9 @@
             // Act
             var actual = client.CheckOrderStatus(queryRequest).Result;
 
-            // Assert
-            Assert.IsTrue(actual.IsSuccess);
-            Assert.AreEqual("APPROVED", actual.Data.status);
+            // ClassicAssert
+            ClassicAssert.IsTrue(actual.IsSuccess);
+            ClassicAssert.AreEqual("APPROVED", actual.Data.status);
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
@@ -14,16 +14,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="nunit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="GithubActionsTestLogger" Version="2.0.1"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="nunit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="GithubActionsTestLogger" Version="2.3.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
   </ItemGroup>

--- a/Zotapay/Zotapay.csproj
+++ b/Zotapay/Zotapay.csproj
@@ -7,7 +7,7 @@
 		<LangVersion>8.0</LangVersion>
 		<NeutralLanguage>en</NeutralLanguage>
 		<PackageId>Zotapay</PackageId>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Authors>kantonov</Authors>
 		<OutputType>Library</OutputType>
 		<Copyright>© 2021 Zota Technology LTD</Copyright>
@@ -25,8 +25,8 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Updated dependency Nuget packages versions
- Switch targeted version to latest LTS - .net 8.0
- Use legacy assert in the tests
- Update github workflow to build & test with the targeted .net 8.0